### PR TITLE
Remove -Sum suffixes from the API.

### DIFF
--- a/examples/Main.hs
+++ b/examples/Main.hs
@@ -25,14 +25,14 @@ newtype Lit a = Lit Int deriving Functor
 -- if we tried to inj it into an 'Expr [Thing1, Thing2]',
 -- we would get an error message that Lit cannot be found in [Thing1, Thing2]
 lit :: (Lit :< fs) => Int -> Expr fs
-lit = In . inj . Lit
+lit = In . inject . Lit
 
 -- parens
 newtype Paren a = Paren a
   deriving Functor
 
 paren :: (Paren :< fs) => Expr fs -> Expr fs
-paren = In . inj . Paren
+paren = In . inject . Paren
 
 -- math
 data Op a
@@ -42,9 +42,9 @@ data Op a
     deriving Functor
 
 (+:), (-:), (*:) :: (Op :< fs) => Expr fs -> Expr fs -> Expr fs
-a +: b = In (inj (Add a b))
-a -: b = In (inj (Sub a b))
-a *: b = In (inj (Mul a b))
+a +: b = In (inject (Add a b))
+a -: b = In (inject (Sub a b))
+a *: b = In (inject (Mul a b))
 
 infixl 6 +:
 infixl 6 -:

--- a/examples/Main.hs
+++ b/examples/Main.hs
@@ -21,18 +21,18 @@ newtype Lit a = Lit Int deriving Functor
 
 -- smart constructor. the :< is pronounced "member":
 -- what this says is that as long as Lit is a member of the type-level
--- list 'fs', we can inject it into an Expr that contains 'fs'
--- if we tried to inject it into an 'Expr [Thing1, Thing2]',
+-- list 'fs', we can inj it into an Expr that contains 'fs'
+-- if we tried to inj it into an 'Expr [Thing1, Thing2]',
 -- we would get an error message that Lit cannot be found in [Thing1, Thing2]
 lit :: (Lit :< fs) => Int -> Expr fs
-lit = In . injectSum . Lit
+lit = In . inj . Lit
 
 -- parens
 newtype Paren a = Paren a
   deriving Functor
 
 paren :: (Paren :< fs) => Expr fs -> Expr fs
-paren = In . injectSum . Paren
+paren = In . inj . Paren
 
 -- math
 data Op a
@@ -42,9 +42,9 @@ data Op a
     deriving Functor
 
 (+:), (-:), (*:) :: (Op :< fs) => Expr fs -> Expr fs -> Expr fs
-a +: b = In (injectSum (Add a b))
-a -: b = In (injectSum (Sub a b))
-a *: b = In (injectSum (Mul a b))
+a +: b = In (inj (Add a b))
+a -: b = In (inj (Sub a b))
+a *: b = In (inj (Mul a b))
 
 infixl 6 +:
 infixl 6 -:

--- a/fastsum.cabal
+++ b/fastsum.cabal
@@ -1,5 +1,5 @@
 name:                fastsum
-version:             0.1.0.0
+version:             0.2.0.0
 synopsis:            A fast open-union type suitable for 100+ contained alternatives
 homepage:            https://github.com/patrickt/fastsum#readme
 license:             BSD3
@@ -22,9 +22,10 @@ library
   default-language:    Haskell2010
 
 executable example
-  hs-source-dirs: examples
-  main-is: Main.hs
-  build-depends: base, fastsum
+  hs-source-dirs:   examples
+  main-is:          Main.hs
+  build-depends:    base, fastsum
+  default-language: Haskell2010
 
 source-repository head
   type:     git

--- a/fastsum.cabal
+++ b/fastsum.cabal
@@ -1,5 +1,5 @@
 name:                fastsum
-version:             0.2.0.0
+version:             0.1.0.0
 synopsis:            A fast open-union type suitable for 100+ contained alternatives
 homepage:            https://github.com/patrickt/fastsum#readme
 license:             BSD3

--- a/src/Data/Sum.hs
+++ b/src/Data/Sum.hs
@@ -39,9 +39,9 @@ The data constructors of Sum are not exported.
 
 module Data.Sum (
   Sum,
-  weakenSum,
-  injectSum,
-  projectSum,
+  weaken,
+  inj,
+  prj,
   type(:<),
   type(:<:),
   Element,
@@ -91,18 +91,18 @@ type family Elements ms r :: Constraint where
 type (ts :<: r) = Elements ts r
 
 -- | Inject a functor into a type-aligned sum.
-injectSum :: forall e r v. (e :< r) => e v -> Sum r v
-injectSum = unsafeInject (unP (elemNo :: P e r))
-{-# INLINE injectSum #-}
+inj :: forall e r v. (e :< r) => e v -> Sum r v
+inj = unsafeInject (unP (elemNo :: P e r))
+{-# INLINE inj #-}
 
 -- | Maybe project a functor out of a type-aligned sum.
-projectSum :: forall e r v. (e :< r) => Sum r v -> Maybe (e v)
-projectSum = unsafeProject (unP (elemNo :: P e r))
-{-# INLINE projectSum #-}
+prj :: forall e r v. (e :< r) => Sum r v -> Maybe (e v)
+prj = unsafeProject (unP (elemNo :: P e r))
+{-# INLINE prj #-}
 
 
-weakenSum :: Sum r w -> Sum (any ': r) w
-weakenSum (Sum n v) = Sum (n+1) v
+weaken :: Sum r w -> Sum (any ': r) w
+weaken (Sum n v) = Sum (n+1) v
 
 type (Element t r) = KnownNat (ElemIndex t r)
 type (t :< r) = Element t r

--- a/src/Data/Sum.hs
+++ b/src/Data/Sum.hs
@@ -40,8 +40,8 @@ The data constructors of Sum are not exported.
 module Data.Sum (
   Sum,
   weaken,
-  inj,
-  prj,
+  inject,
+  project,
   type(:<),
   type(:<:),
   Element,
@@ -91,14 +91,14 @@ type family Elements ms r :: Constraint where
 type (ts :<: r) = Elements ts r
 
 -- | Inject a functor into a type-aligned sum.
-inj :: forall e r v. (e :< r) => e v -> Sum r v
-inj = unsafeInject (unP (elemNo :: P e r))
-{-# INLINE inj #-}
+inject :: forall e r v. (e :< r) => e v -> Sum r v
+inject = unsafeInject (unP (elemNo :: P e r))
+{-# INLINE inject #-}
 
 -- | Maybe project a functor out of a type-aligned sum.
-prj :: forall e r v. (e :< r) => Sum r v -> Maybe (e v)
-prj = unsafeProject (unP (elemNo :: P e r))
-{-# INLINE prj #-}
+project :: forall e r v. (e :< r) => Sum r v -> Maybe (e v)
+project = unsafeProject (unP (elemNo :: P e r))
+{-# INLINE project #-}
 
 
 weaken :: Sum r w -> Sum (any ': r) w


### PR DESCRIPTION
There's no need to keep these otiose suffixes around, since these can
be imported qualified if there is a collision with some other union
type.

Bumps to 0.2.0.0, since this is backwards-incompatible.