### PR TITLE
lifts upper bound on template-haskell for compatibility with ghc-8.10.2

### DIFF
--- a/fastsum.cabal
+++ b/fastsum.cabal
@@ -42,7 +42,7 @@ library
                      , deepseq >= 1.4 && <2
                      , ghc-prim >= 0.5 && <1
                      , hashable >= 1.2 && <2
-                     , template-haskell >= 2.12 && < 2.16
+                     , template-haskell >= 2.12 && < 2.17
   default-language:    Haskell2010
 
 executable examples


### PR DESCRIPTION
I tested the build and it seems to have built successfully with the upper bound lifted on TH. I needed this for usage with ghc-8.10.2. Let me know if there is anything you want me to test specifically.