### PR TITLE
More precise hashable bound

### DIFF
--- a/fastsum.cabal
+++ b/fastsum.cabal
@@ -41,7 +41,7 @@ library
   build-depends:       base >= 4.7 && < 5
                      , deepseq >= 1.4 && <2
                      , ghc-prim >= 0.5 && <1
-                     , hashable >= 1.2 && <2
+                     , hashable >= 1.2 && <1.4
                      , template-haskell >= 2.12 && < 2.17
   default-language:    Haskell2010
 


### PR DESCRIPTION
hashable 1.4 adds Eq as superclass to Hashable

This change causes these two error messages in this package:

```
src/Data/Sum.hs:241:10: error:
    • Could not deduce (Apply Eq1 fs)
        arising from the superclasses of an instance declaration
      from the context: Apply Hashable1 fs
        bound by the instance declaration at src/Data/Sum.hs:241:10-49
    • In the instance declaration for ‘Hashable1 (Sum fs)’
    |
241 | instance Apply Hashable1 fs => Hashable1 (Sum fs) where
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

src/Data/Sum.hs:245:10: error:
    • Could not deduce (Apply Eq1 fs)
        arising from the superclasses of an instance declaration
      from the context: (Apply Hashable1 fs, Hashable a)
        bound by the instance declaration at src/Data/Sum.hs:245:10-64
    • In the instance declaration for ‘Hashable (Sum fs a)’
    |
245 | instance (Apply Hashable1 fs, Hashable a) => Hashable (Sum fs a) where
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```