### PR TITLE
Require Eq1 for Hashable1 instances.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,8 @@
-# v0.1.1.2
+# v0.2.0.0
 
-Enable use of `template-haskell` versions >= 2.19.
+Support GHC 9.2 by enabling use of `template-haskell` versions >= 2.19.
+
+Add an `Eq1` constraint to the `Hashable1` constraint to satisfy newer `hashable` versions.
 
 # v0.1.1.1
 

--- a/fastsum.cabal
+++ b/fastsum.cabal
@@ -1,7 +1,7 @@
 cabal-version:       2.4
 
 name:                fastsum
-version:             0.1.1.2
+version:             0.2.0.0
 synopsis:            A fast open-union type suitable for 100+ contained alternatives
 homepage:            https://github.com/patrickt/fastsum#readme
 license:             BSD-3-Clause

--- a/src/Data/Sum.hs
+++ b/src/Data/Sum.hs
@@ -238,11 +238,11 @@ instance (Apply Show1 fs, Show a) => Show (Sum fs a) where
   {-# INLINABLE showsPrec #-}
 
 
-instance Apply Hashable1 fs => Hashable1 (Sum fs) where
+instance (Apply Eq1 fs, Apply Hashable1 fs) => Hashable1 (Sum fs) where
   liftHashWithSalt hashWithSalt' salt u@(Sum n _) = salt `hashWithSalt` apply @Hashable1 (liftHashWithSalt hashWithSalt' n) u
   {-# INLINABLE liftHashWithSalt #-}
 
-instance (Apply Hashable1 fs, Hashable a) => Hashable (Sum fs a) where
+instance (Apply Eq1 fs, Apply Hashable1 fs, Hashable a) => Hashable (Sum fs a) where
   hashWithSalt = hashWithSalt1
   {-# INLINABLE hashWithSalt #-}
 


### PR DESCRIPTION
Newer hashable versions require an Eq1 constraint. This is appropriate, as I
can't think of a real-world data structure that would admit a Hashable instance
but not an Eq one.

Thanks to @noughtmare for pointing this issue out.